### PR TITLE
Add types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.13",
     "description": "Email parser for browser environments",
     "main": "dist/postal-mime.js",
+    "types": "postal-mime.d.ts",
     "scripts": {
         "test": "eslint",
         "build": "webpack",

--- a/postal-mime.d.ts
+++ b/postal-mime.d.ts
@@ -1,0 +1,45 @@
+declare namespace postalMime {
+    type RawEmail = string | ArrayBuffer | Blob | Buffer;
+
+    type Header = Record<string, string>;
+
+    type Address = {
+        address: string;
+        name: string;
+    };
+
+    type Attachment = {
+        filename: string;
+        mimeType: string;
+        disposition: 'attachment' | 'inline' | null;
+        related?: boolean;
+        contentId?: string;
+        content: string;
+    };
+
+    type Email = {
+        headers: Header[];
+        from: Address;
+        sender?: Address;
+        replyTo?: Address[];
+        deliveredTo?: string;
+        returnPath?: string;
+        to: Address[];
+        cc?: Address[];
+        bcc?: Address[];
+        subject?: string;
+        messageId: string;
+        inReplyTo?: string;
+        references?: string;
+        date?: string;
+        html?: string;
+        text?: string;
+        attachments: Attachment[];
+    };
+}
+
+declare class PostalMime {
+    parse(email: postalMime.RawEmail): Promise<postalMime.Email>;
+}
+
+export default PostalMime;


### PR DESCRIPTION
Small PR to add types to postal-mime. 

I only added types for `parse` for now, since that's the only documented exposed function.

Closes #7