### PR TITLE
chore: make repo windows compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 node_modules
 .DS_Store
 package-lock.json
+yarn.lock
+.idea

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "test": "eslint",
         "build": "webpack",
-        "prepare": "rm -rf dist/postal-mime.js && NODE_ENV=production npm run build && echo prepared",
+        "prepare": "rm -f dist/* && cross-env NODE_ENV=production npm run build && echo prepared",
         "prepublish": "npm run prepare"
     },
     "keywords": [
@@ -22,6 +22,7 @@
         "eslint-cli": "1.1.1",
         "iframe-resizer": "4.3.2",
         "webpack": "5.72.1",
-        "webpack-cli": "4.9.2"
+        "webpack-cli": "4.9.2",
+        "cross-env": "7.0.3"
     }
 }


### PR DESCRIPTION
- A quick fix that makes this repo Windows-compatible, meaning that you can run `npm install` or `yarn` without erroring out.
- Also a quick fix to actually remove the node file as well before recompiling.