### PR TITLE
Fixed attachment exported type

### DIFF
--- a/postal-mime.d.ts
+++ b/postal-mime.d.ts
@@ -13,7 +13,7 @@ export type Attachment = {
 	disposition: "attachment" | "inline" | null;
 	related?: boolean;
 	contentId?: string;
-	content: string;
+	content: ArrayBuffer;
 };
 
 export type Email = {


### PR DESCRIPTION
Attachment content seems to be an ArrayBuffer and not a string.