### PR TITLE
Make to optional

### DIFF
--- a/postal-mime.d.ts
+++ b/postal-mime.d.ts
@@ -23,7 +23,7 @@ export type Email = {
 	replyTo?: Address[];
 	deliveredTo?: string;
 	returnPath?: string;
-	to: Address[];
+	to?: Address[];
 	cc?: Address[];
 	bcc?: Address[];
 	subject?: string;


### PR DESCRIPTION
If the email has no `To: ...` set, `to` will be undefined. This change reflects that.

Resolve https://github.com/postalsys/postal-mime/issues/18