### PR TITLE
fix(module): add types to module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "Email parser for browser environments",
     "main": "./src/postal-mime.js",
     "exports": {
-        "import": "./src/postal-mime.js"
+        "import": "./src/postal-mime.js",
+        "types": "./postal-mime.d.ts"
     },
     "type": "module",
     "types": "postal-mime.d.ts",


### PR DESCRIPTION
Typescript can't use declaration files when `compileOptions.moduleResolution` set to `bundler`

![image](https://github.com/postalsys/postal-mime/assets/66567192/42628ec0-1677-43d1-ae47-7de88e2a12d5)