### PR TITLE
Add a type definition for PostalMime.parse()

### DIFF
--- a/postal-mime.d.ts
+++ b/postal-mime.d.ts
@@ -37,6 +37,7 @@ export type Email = {
 };
 
 declare class PostalMime {
+	static parse(email: RawEmail): Promise<Email>;
 	parse(email: RawEmail): Promise<Email>;
 }
 


### PR DESCRIPTION
Hello, Thank you for your great library 😄
I'm using this on serverless edge functions.

`PostalMime.parse()` method was added in [v2.2.0](https://github.com/postalsys/postal-mime/releases/tag/v2.2.0), but when I use it in TypeScript I get a type error.

```
email.ts:61:33 - error TS2339: Property 'parse' does not exist on type 'typeof PostalMime'.

61   const mail = await PostalMime.parse(data);
                                   ~~~~~
```

I see there is not type definition for it yet.

It would be great if you could add this change.

Thanks,
