### PR TITLE
Fix exception when parsing text emails

### DIFF
--- a/src/postal-mime.js
+++ b/src/postal-mime.js
@@ -328,7 +328,7 @@ export default class PostalMime {
         }
 
         // Should it throw for an empty value instead of defaulting to an empty ArrayBuffer?
-        buf = buf || ArrayBuffer(0);
+        buf = buf || new ArrayBuffer(0);
 
         // Cast string input to Uint8Array
         if (typeof buf === 'string') {


### PR DESCRIPTION
When parsing a text email, there is a scenario where the ArrayBuffer needs to be initialized from scratch instaed from the readable stream. We need to use `new ArrayBuffer` instead of just `ArrayBuffer` otherwise an exception is thrown.

![image](https://github.com/postalsys/postal-mime/assets/610521/ec044397-5ab6-4f6e-8173-5d9cab137939)

(Sorry for the minified image)