### PR TITLE
update Address types

### DIFF
--- a/postal-mime.d.ts
+++ b/postal-mime.d.ts
@@ -5,11 +5,17 @@ export type Header = {
     value: string;
 };
 
-export type Address = {
+export type Mailbox = {
     name: string;
-    address?: string;
-    group?: Address[]
+    address: string;
 };
+
+export type Address =
+    | Mailbox
+    | {
+          name: string;
+          group: Mailbox[];
+      };
 
 export type Attachment = {
     filename: string | null;


### PR DESCRIPTION
I'm updating the Typescript types for `Address`. I add the `Mailbox` type, which requires `name` and `address`. Address may be a `Mailbox` or an object with a required `name` and `group`. Group is an array of `Mailbox`.

The reason for this PR is to make it clearer when `address` or `group` may be undefined: Group and Address are mutually exclusive. Also, Group cannot be recursive (Group cannot contain additional Groups).

(To be clear, I did not audit `address-parser.js`; I'm just going off https://datatracker.ietf.org/doc/html/rfc2822#section-3.4 The RFC states that name is optional, but I'm keeping it required here since it looks like we fall back to emptystring)